### PR TITLE
working example of catalog and catalog item

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+.idea

--- a/sample/repo/projects/BAR_2/catalogs/Test Catalog/catalog.dsl
+++ b/sample/repo/projects/BAR_2/catalogs/Test Catalog/catalog.dsl
@@ -1,0 +1,1 @@
+catalog 'Test Catalog'

--- a/sample/repo/projects/BAR_2/catalogs/Test Catalog/catalogItems/Service OnBoarding/catalogItem.dsl
+++ b/sample/repo/projects/BAR_2/catalogs/Test Catalog/catalogItems/Service OnBoarding/catalogItem.dsl
@@ -1,0 +1,15 @@
+def catItemName='Service OnBoarding'
+
+catalogItem catItemName, catalogName: catalogName, {
+ description: '''<xml>
+ <title>
+   Add a new Service to ElectricFlow
+ </title>
+
+ <htmlData>
+   <![CDATA[
+
+   ]]>
+ </htmlData>
+</xml>'''
+}


### PR DESCRIPTION
Note the reference to 'catalogName' in catalogItem.dsl: https://github.com/electric-cloud/EC-DslDeploy/blob/24bfd2b96b72cd9e0cc8012ba11220c5b1ce8bd2/sample/repo/projects/BAR_2/catalogs/Test%20Catalog/catalogItems/Service%20OnBoarding/catalogItem.dsl#L3

```catalogName: catalogName``` gets resolved when the dsl is evaluated using the 'catalogName' passed in as a bind variable in evalInlineDsl.
Btw, this folder structure expects the catalog item to be read from a sub-folder called *catalogItems* instead of items to be consistent with the name of the object. I am not able to check in the corresponding change for this to BaseProject.groovy as the file is very different in master at this point. But it should be a simple change to make for you on the latest version of the file.