### PR TITLE
NBM-29494 Remove 'command' option from DSL if exporting object does not have file references

### DIFF
--- a/dsl/com/electriccloud/commander/dsl/util/BaseObject.groovy
+++ b/dsl/com/electriccloud/commander/dsl/util/BaseObject.groovy
@@ -42,9 +42,6 @@ abstract class BaseObject extends DslDelegatingScript {
                   "steps", "reportingFilters", "stages", "stateDefinitions", "tasks",
                   "widgets");
 
-  private static final Map<String, String> ENCODE_MAP = ["/": "@2F", "\\": "@5C"] as HashMap
-  private static final Map<String, String> DECODE_MAP = ["@2F": "/", "@5C": "\\"] as HashMap
-
   def jsonSlurper = new JsonSlurper()
 
   // return the object.groovy or object.dsl

--- a/dsl/properties/scripts/GenerateDslHelper.groovy
+++ b/dsl/properties/scripts/GenerateDslHelper.groovy
@@ -7,6 +7,7 @@ import java.util.stream.Collectors
 class GenerateDslHelper {
 
     private static final String METADATA_FILE = "metadata.json"
+    private static final Pattern COMMAND = Pattern.compile("command = '.*'")
 
     //
     private def electricFlow
@@ -204,6 +205,13 @@ class GenerateDslHelper {
             objDslFile << 'import java.io.File\n\n'
             dsl = dsl.replaceAll("'(new File\\(.*,.*\\).text)'", "\$1")
             dsl = encodePath(dsl)
+        }
+        else {
+            Matcher matcher = COMMAND.matcher(dsl)
+            while (matcher.find()) {
+                dsl = dsl.replace(matcher.group(), '')
+            }
+
         }
 
         objDslFile << dsl

--- a/specs/src/test/resources/procedure_with_empty_command.dsl
+++ b/specs/src/test/resources/procedure_with_empty_command.dsl
@@ -1,0 +1,19 @@
+
+project args.projectName, {
+
+  procedure 'proc1', {
+
+    step 'step1', {
+      command = 'echo Test'
+    }
+  }
+
+  procedure 'proc2', {
+
+    step 'Checkout from GitHub', {
+      command = ''
+      subprocedure = 'CheckoutCode'
+      subproject = '/plugins/ECSCM-Git/project'
+    }
+  }
+}


### PR DESCRIPTION
Preflight: https://viva.beescloud.com/commander/link/jobDetails/jobs/75d0e05f-d7bf-11ea-9380-42010ac90206