### PR TITLE
CEV-27441

### DIFF
--- a/dsl/procedures/importDslFromGit/form.xml
+++ b/dsl/procedures/importDslFromGit/form.xml
@@ -33,6 +33,14 @@
     <documentation>The directory on the resource where the source tree will be created and from where the DSL files are read to be imported in Flow server. This directory must be accessible from the Flow server. In a clustered deployment, all Flow server nodes must have access to this directory.</documentation>
   </formElement>
   <formElement>
+    <type>entry</type>
+    <label>Relative path to DSL files:</label>
+    <property>relPath</property>
+    <required>0</required>
+    <value/>
+    <documentation>If the DSL files are not located at the top-level in the repository, then specify the relative path to the directory containing the DSL files within the repository. E.g., 'scripts/dsls' where the dsl files are located in the following sub-directories in the repository 'scripts/dsls/projects' and 'scripts/dsls/resources'.</documentation>
+  </formElement>
+  <formElement>
     <type>checkbox</type>
     <label>Cleanup?:</label>
     <property>cleanup</property>

--- a/dsl/procedures/importDslFromGit/procedure.dsl
+++ b/dsl/procedures/importDslFromGit/procedure.dsl
@@ -25,7 +25,7 @@ procedure procName, {
             subprocedure: 'installDslFromDirectory',
             errorHandling: 'abortProcedure',
             actualParameter: [
-                    directory: '$[dest]',
+                    directory: '$[/javascript if (myCall.relPath) { myCall.dest + \'/\' + myCall.relPath;} else {myCall.dest;}]',
                     pool     : '$[rsrcName]',
                     overwrite: '$[overwrite]',
                     localMode: '$[localMode]',


### PR DESCRIPTION
 Missed "Relative path to DSL files" parameter in importDslFromGit EC-DslDeploy plugin procedure that is present in service catalog
preflight: https://artemis.nimbus.beescloud.com/flow/#pipeline-run/d56c2bcf-3013-11eb-853c-42010a1eb00c/fa7f721e-7076-11eb-88c7-42010a1eb026