### PR TITLE
Refactored to exclude task group recursion

### DIFF
--- a/specs/src/test/resources/pipeline_with_group_task.dsl
+++ b/specs/src/test/resources/pipeline_with_group_task.dsl
@@ -1,0 +1,26 @@
+project args.projectName, {
+    pipeline 'pipeline1', {
+            stage 'stage1', {
+                task 'cmd1', {
+                    actualParameter = [
+                        'commandToRun': 'echo test1',
+                    ]
+                    subpluginKey = 'EC-Core'
+                    subprocedure = 'RunCommand'
+                    taskType = 'COMMAND'
+                }
+                task 'group1', {
+                    taskType = 'GROUP'
+                    task 'cmd2', {
+                        actualParameter = [
+                            'commandToRun': 'echo test2',
+                        ]
+                        subpluginKey = 'EC-Core'
+                        subprocedure = 'RunCommand'
+                        taskType = 'COMMAND'
+                    }
+                }
+            }
+    }
+
+}


### PR DESCRIPTION
A conditional check was introduced to  inspect stage children so that task groups are ignored for fileRefInfo check. Otherwise they fall into the recursive function when the task group children are detected.